### PR TITLE
Add moderation team charter

### DIFF
--- a/moderation-team-charter.md
+++ b/moderation-team-charter.md
@@ -6,23 +6,23 @@ Going forward, we propose to define the Moderation Team Charter to clearly spell
 
 # Mission
 
-To ensure that Rust Project is, and continues to be, a welcoming place for everyone. We aim to support individuals and teams in creating a healthy and collaborative environment that keeps contributors interacting in a productive and respectful way.
+To ensure that the Rust Project is, and continues to be, a welcoming place for everyone. We aim to support individuals and teams in creating a healthy and collaborative environment that keeps contributors interacting in a productive and respectful way.
 
-## How does the Moderation Team help achieve the goals of the Rust Project?
+## How does the Moderation team help achieve the goals of the Rust Project?
 
 * Facilitation: Help lead discussions on a topics that may require a third party facilitator.
 * Intervention: Serve as mediators in cases where disputes among individuals have risen to a level that intervention is deemed necessary.
 
 # Purview
 
-* [[D]] Establishing moderation policy for the entire project
-    * The code of conduct
-* [[D]] The Moderation team repo
-* [[D]] The Moderation team zulip streams
-* [[A]] Moderation of all official Rust venues
-* [[R]] Conflict transformation and mediation
+* [[D]] Establishing moderation policy for the entire project.
+    * The code of conduct.
+* [[D]] The Moderation team repository.
+* [[D]] The Moderation team Zulip streams.
+* [[A]] Moderation of all official Rust venues.
+* [[R]] Conflict transformation and mediation.
 * [[R]] Limiting individual participation within the project.
-* [[C]] Reviewing proposed new team members
+* [[C]] Reviewing proposed new team members.
 
 ## How does this group make decisions?
 
@@ -52,10 +52,10 @@ The Moderation team uses a role based system to assign specific responsibilities
 ### Secretary
 
 * Responsible for
-  * Taking notes in team meetings
-  * Management of team documentation and policy
-  * Tracking terms and timelines for policy items and bringing those items to the team for discussion as needed
-  * If the secretary is not available for a meeting, any participant in the meeting may volunteer to take notes.
+  * Taking notes in team meetings.
+    * If the secretary is not available for a meeting, any participant in the meeting may volunteer to take notes.
+  * Management of team documentation and policy.
+  * Tracking terms and timelines for policy items and bringing those items to the team for discussion as needed.
 
 ### Facilitator
 
@@ -80,13 +80,13 @@ Team members are expected to:
 
 ## How is team membership managed?
 
-All memberships on the Moderation team and or moderation subteams are contingent on review of the project members past interactions and behavior. 
+All memberships on the Moderation team and or Moderation subteams are contingent on review of the project members past interactions and behavior. 
 
 **People join the team by**: participating as a trusted member of the Rust Project.
 
 The following are criteria for being a moderator:
 
-* You are an existing member of a moderation subteam or you are an existing member of another Rust Project team.
+* You are an existing member of a Moderation subteam or you are an existing member of another Rust Project team.
 * All members of the top level Moderation team, including the contingent moderators, consent to you joining the team. 
 
 If you are interested in joining the Moderation team please reach out to any member of the Moderation team or the council.

--- a/moderation-team-charter.md
+++ b/moderation-team-charter.md
@@ -1,0 +1,115 @@
+# Rust Moderation Team Charter
+
+Up to this point the Moderation team has existed largely without well defined structure and operations.
+
+Going forward, we propose to define the Moderation Team Charter to clearly spell out its purview, existing policy, and procedures. Additionally we plan to expand the responsibilities of the Moderation team to include aspects of collaboration.
+
+# Mission
+
+To ensure that Rust Project is, and continues to be, a welcoming place for everyone. We aim to support individuals and teams in creating a healthy and collaborative environment that keeps contributors interacting in a productive and respectful way.
+
+## How does the Moderation Team help achieve the goals of the Rust Project?
+
+* Facilitation: Help lead discussions on a topics that may require a third party facilitator.
+* Intervention: Serve as mediators in cases where disputes among individuals have risen to a level that intervention is deemed necessary.
+
+# Purview
+
+* [[D]] Establishing moderation policy for the entire project
+    * The code of conduct
+* [[D]] The Moderation team repo
+* [[D]] The Moderation team zulip streams
+* [[A]] Moderation of all official Rust venues
+* [[R]] Conflict transformation and mediation
+* [[R]] Limiting individual participation within the project.
+* [[C]] Reviewing proposed new team members
+
+## How does this group make decisions?
+
+This team uses a consent based decision making process where consent is reached by all current team members and work is delegated to individuals.
+
+## What specifically is outside Moderation purview?
+
+The following are outside of moderation purview
+* The [/r/rust] subreddit.
+* The [unofficial rust-lang community discord].
+* Other platforms outside of the official venues.
+
+# Team Processes
+
+The Moderation team uses a role based system to assign specific responsibilities to individual members. The following roles exist on the team:
+
+### Team Lead
+
+* Defined in the [team lead role description document].
+* The Team Lead role has a 1 year term limit and is decided upon by the team by consent.
+* The same person may fill the role for multiple consecutive terms if the team feels they are still the best person for the position. 
+
+### Council Representative
+
+* Defined in the [council representative role description document].
+
+### Secretary
+
+* Responsible for
+  * Taking notes in team meetings
+  * Management of team documentation and policy
+  * Tracking terms and timelines for policy items and bringing those items to the team for discussion as needed
+  * If the secretary is not available for a meeting, any participant in the meeting may volunteer to take notes.
+
+### Facilitator
+
+* Ensures team meetings stay on track and that all meetings have an agenda.
+    
+The Facilitator and Secretary roles have no term limits and can be rotated between team members as necessary. 
+
+## Contact Point
+
+In general if you wish to contact the Moderation team you should email [mods@rust-lang.org].
+
+The point of contact for the state of the team is: the team lead specified on [https://github.com/rust-lang/team]. They are the authoritative ‘switchboard’ for meta information about the team, and are the primary owner of this charter.
+
+## Team Membership
+
+Team members are expected to:
+
+* Agree with and exemplify Moderation team principles.
+* Participate in team activities and responsibilities.
+* Handle small scale conflicts as they arise on the various venues.
+* Provide guidance and mediation for conflicts.
+
+## How is team membership managed?
+
+All memberships on the Moderation team and or moderation subteams are contingent on review of the project members past interactions and behavior. 
+
+**People join the team by**: participating as a trusted member of the Rust Project.
+
+The following are criteria for being a moderator:
+
+* You are an existing member of a moderation subteam or you are an existing member of another Rust Project team.
+* All members of the top level Moderation team, including the contingent moderators, consent to you joining the team. 
+
+If you are interested in joining the Moderation team please reach out to any member of the Moderation team or the council.
+
+**People leave the team by**: handing in their notice (ideally at least a month), or voluntarily stepping down.
+
+### Contingent Moderators
+
+The Moderation team has a separate set of standby team members known as contingent moderators. The responsibilities of the contingent moderators are described in the governance rfc. If you are interested in becoming a contingent moderator please reach out to any member of the Moderation team or the council.
+
+## Where does this team work?
+
+This team works across all project spaces. This team uses a separate Zulip instance for communicating with team members and subteam members, though much of the communication happens in direct messages on various platforms.
+
+This team has weekly internal sync meetings. Meeting minutes are recorded but kept private.
+
+[D]: ../../common/darci.md#decision-maker
+[A]: ../../common/darci.md#accountable-for-results
+[R]: ../../common/darci.md#responsible-for-work
+[C]: ../../common/darci.md#consulted-for-input
+[/r/rust]: https://old.reddit.com/r/rust/
+[unofficial rust-lang community discord]: https://discord.gg/rust-lang-community
+[mods@rust-lang.org]: mailto:mods@rust-lang.org
+[https://github.com/rust-lang/team]: https://github.com/rust-lang/team
+[team lead role description document]: https://hackmd.io/@rust-lang-governance-wg/rkRNINMZ2
+[council representative role description document]:  https://hackmd.io/vYh6LE4jRC-4phNjHfYuCA?view


### PR DESCRIPTION
This PR introduces a draft of the Moderation team charter. This document is intended to provide a foundation for the Moderation team to build upon in the future and define basic policy and structure for the team. 

[Rendered](https://github.com/rust-lang/moderation-team/blob/0c117fffd7c59bf29b247c62ee8d0c469edbf58f/moderation-team-charter.md)